### PR TITLE
Updater Changes

### DIFF
--- a/FFXIVAPP.Client/FFXIVAPP.Client.csproj
+++ b/FFXIVAPP.Client/FFXIVAPP.Client.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Utilities\MicroStopwatch.cs" />
     <Compile Include="Utilities\MicroTimer.cs" />
     <Compile Include="Utilities\MicroTimerEventArgs.cs" />
+    <Compile Include="Utilities\UpdateUtilities.cs" />
     <Compile Include="ViewModels\AboutViewModel.cs" />
     <Compile Include="ViewModels\UpdateViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />

--- a/FFXIVAPP.Client/Initializer.cs
+++ b/FFXIVAPP.Client/Initializer.cs
@@ -371,9 +371,12 @@ namespace FFXIVAPP.Client
                                             Files = new List<PluginFile>(pluginFiles.Select(pluginFile => new PluginFile
                                             {
                                                 Location = pluginFile["Location"].ToString(),
-                                                Name = pluginFile["Name"].ToString()
+                                                Name = pluginFile["Name"].ToString(),
+                                                Checksum = pluginFile["Checksum"] == null ? "" : pluginFile["Checksum"].ToString()
                                             })),
                                             Name = pluginInfo["Name"].ToString(),
+                                            FriendlyName = pluginInfo["FriendlyName"] == null ? pluginInfo["Name"].ToString() : pluginInfo["FriendlyName"].ToString(),
+                                            Description = pluginInfo["Description"] == null ? "" : pluginInfo["Description"].ToString(),
                                             SourceURI = pluginInfo["SourceURI"].ToString(),
                                             LatestVersion = pluginInfo["Version"].ToString()
                                         };

--- a/FFXIVAPP.Client/Models/PluginDownloadItem.cs
+++ b/FFXIVAPP.Client/Models/PluginDownloadItem.cs
@@ -39,6 +39,8 @@ namespace FFXIVAPP.Client.Models
         private List<PluginFile> _files;
         private string _latestVersion;
         private string _name;
+        private string _friendlyName;
+        private string _description;
         private string _sourceUri;
         private PluginStatus _status;
 
@@ -48,6 +50,26 @@ namespace FFXIVAPP.Client.Models
             set
             {
                 _name = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string FriendlyName
+        {
+            get { return _friendlyName; }
+            set
+            {
+                _friendlyName = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string Description
+        {
+            get { return _description; }
+            set
+            {
+                _description = value;
                 RaisePropertyChanged();
             }
         }

--- a/FFXIVAPP.Client/Models/PluginFile.cs
+++ b/FFXIVAPP.Client/Models/PluginFile.cs
@@ -36,6 +36,7 @@ namespace FFXIVAPP.Client.Models
     {
         private string _location;
         private string _name;
+        private string _checksum;
 
         public string Name
         {
@@ -53,6 +54,16 @@ namespace FFXIVAPP.Client.Models
             set
             {
                 _location = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string Checksum
+        {
+            get { return _checksum; }
+            set
+            {
+                _checksum = value;
                 RaisePropertyChanged();
             }
         }

--- a/FFXIVAPP.Client/Utilities/UpdateUtilities.cs
+++ b/FFXIVAPP.Client/Utilities/UpdateUtilities.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace FFXIVAPP.Client.Utilities
+{
+    public static class UpdateUtilities
+    {
+        /// <summary>
+        /// Compares a file against an expected checksum.
+        /// </summary>
+        /// <param name="FilePath">Path to file</param>
+        /// <param name="Checksum">Expected MD5 checksum</param>
+        /// <returns>True if the file matches. False if the file doesn't match OR doesn't exist.</returns>
+        public static bool VerifyFile(string FilePath, string Checksum)
+        {
+            if (!File.Exists(FilePath))
+            {
+                return false;
+            }
+
+            return GetFileHash(FilePath).Equals(Checksum, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Computes a file's checksum
+        /// </summary>
+        /// <param name="FilePath">Path to file</param>
+        /// <returns>MD5 checksum for the file, or an empty string if the file doesn't exist.</returns>
+        public static string GetFileHash(string FilePath)
+        {
+            string FileHash = "";
+
+            if (!File.Exists(FilePath))
+            {
+                return FileHash;
+            }
+
+            using (FileStream file = new FileStream(FilePath, FileMode.Open, FileAccess.Read))
+            {
+                using (MD5 md5 = new MD5CryptoServiceProvider())
+                {
+                    byte[] retVal = md5.ComputeHash(file);
+                    file.Close();
+
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < retVal.Length; i++)
+                    {
+                        sb.Append(retVal[i].ToString("x2"));
+                    }
+                    FileHash = sb.ToString();
+                }
+            }
+
+            return FileHash;
+        }
+
+    }
+}

--- a/FFXIVAPP.Client/Views/UpdateView.xaml
+++ b/FFXIVAPP.Client/Views/UpdateView.xaml
@@ -128,10 +128,11 @@
                             </GroupStyle>
                         </DataGrid.GroupStyle>
                         <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding Name}"
+                            <DataGridTextColumn Binding="{Binding FriendlyName}"
                                                 Header="{Binding Locale[app_NameHeader],
                                                                  Source={StaticResource AppProperties}}"
-                                                Utilities:GridViewSort.PropertyName="Name" />
+                                                IsReadOnly="True"
+                                                Utilities:GridViewSort.PropertyName="FriendlyName" />
                             <DataGridTextColumn Binding="{Binding CurrentVersion}"
                                                 Header="{Binding Locale[app_CurrentVersionHeader],
                                                                  Source={StaticResource AppProperties}}"
@@ -152,11 +153,10 @@
                                                                  Source={StaticResource AppProperties}}"
                                                 IsReadOnly="True"
                                                 Utilities:GridViewSort.PropertyName="Status" />
-                            <DataGridTextColumn Binding="{Binding SourceURI}"
-                                                Header="{Binding Locale[app_SourceURIHeader],
-                                                                 Source={StaticResource AppProperties}}"
+                            <DataGridTextColumn Binding="{Binding Description}"
+                                                Header="Description"
                                                 IsReadOnly="True"
-                                                Utilities:GridViewSort.PropertyName="SourceURI" />
+                                                Utilities:GridViewSort.PropertyName="Description" />
                         </DataGrid.Columns>
                     </DataGrid>
                     <DockPanel Grid.Row="3"
@@ -172,12 +172,8 @@
                                        RenderOptions.BitmapScalingMode="HighQuality"
                                        Source="/FFXIVAPP.Client;component/Resources/Media/Images/Refresh.png" />
                                 <TextBlock Padding="3,0,3,0"
-                                           Text="{Binding Locale[app_RefreshPluginsButtonText],
-                                                          Source={StaticResource AppProperties},
-                                                          Converter={StaticResource ToUpperConverter}}"
-                                           Visibility="{Binding EnableHelpLabels,
-                                                                Converter={StaticResource VisibilityConverter},
-                                                                Source={x:Static Properties:Settings.Default}}" />
+                                           Text="{Binding Locale[app_RefreshPluginsButtonText], Converter={StaticResource ToUpperConverter}, Source={StaticResource AppProperties}}"
+                                           Visibility="{Binding EnableHelpLabels, Converter={StaticResource VisibilityConverter}, Source={x:Static Properties:Settings.Default}}" />
                             </StackPanel>
                         </Button>
                         <Button Height="28"


### PR DESCRIPTION
- Added a "Friendly Name" and "Description" to the Updates tab.
- Uses checksum per file to determine if it has to download a file or not during updates. 

Plugins need to update their VERSION.json to take advantage of these changes. 
Can generate a VERSION.json file with:
https://github.com/cjmanca/FFXIVDBM.Plugin/blob/master/distribution/GenerateVersionJSON.exe?raw=true
