### PR TITLE
Fix blurry images

### DIFF
--- a/FFXIVAPP.Client/ShellView.xaml
+++ b/FFXIVAPP.Client/ShellView.xaml
@@ -31,6 +31,7 @@
                                          Source={x:Static Properties:Settings.Default}}"
                            Topmost="{Binding TopMost,
                                              Source={x:Static Properties:Settings.Default}}"
+                           UseLayoutRounding="True"
                            WindowStyle="None"
                            d:DesignHeight="720"
                            d:DesignWidth="480"


### PR DESCRIPTION
Enabled layout rounding on the root window to prevent images from having fractional coordinates and appearing blurry.